### PR TITLE
Add Spanish README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-﻿# EasyReforge
+# EasyReforge
+
+[Español](README_es.md)
 
 [reForge](https://github.com/Panchovix/stable-diffusion-webui-reForge) でお手軽に高速画像生成する EasyReforge です。  
 [NoobAi](https://civitai.com/models/833294) の Epsilon-Prediction 版 ( **NoobE** ) と V-Prediction 版 ( **NoobV** ) を主に扱います。

--- a/README_es.md
+++ b/README_es.md
@@ -1,0 +1,415 @@
+# EasyRefoge
+
+[reForge](https://github.com/Panchovix/stable-diffusion-webui-reForge) でお手軽に高速画像生成する EasyReforge です。  
+[NoobAi](https://civitai.com/models/833294) の Epsilon-Prediction 版 ( **NoobE** ) と V-Prediction 版 ( **NoobV** ) を主に扱います。
+
+- Instalando un click.
+RTFOX 3060 VRAM 12GB para generar FALHD en 10 segundos.
+- Ingrese una fórmula de extensión conveniente.
+- Descargue una fórmula de recurso, como el modelo Lora-Wild Adheiler, con la tecla Cbivii de configuración
+
+わからないことや不具合や要望がありましたら、 [@Zuntan03](https://x.com/Zuntan03) や [Issues](https://github.com/Zuntan03/EasyReforge/issues) にお知らせください。
+
+# Instalar como
+
+1.  [EasyReforgeInstaller.bat](https://github.com/Zuntan03/EasyReforge/raw/main/EasyReforge/EasyReforgeInstaller.bat?ver=1) を右クリックから保存します。
+- Debe deshabilitarse la detección de virus y deshabilitar la VPN, no como Windows Diffener, como el administrador de la computadora, o el administrador de la computadora, o el abasto.
+2. yC: / EasyRefoge/ year, en la carpeta ** a la que se instalará una ruta poco profunda, como &quot; EasyRefoge/ &quot; , haga doble clic en "EasyRefogeInstaller.batell.bats. &quot; .
+- El ordenador está protegido por Windows.
+Descargue los modelos necesarios para el movimiento de la espiral. ¿Está seguro? [y/n] en blanco.]
+4. En el lugar donde se instalará la instalación, se instalará la instalación de Microsoft Visual C+Restitute.
+5. インストールが問題なく終了したら [使い方](https://github.com/Zuntan03/EasyReforge/#使い方) へ。
+
+**インストールで問題が発生したら『[インストールのトラブルシューティング](https://github.com/Zuntan03/EasyReforge/wiki/%E3%83%88%E3%83%A9%E3%83%96%E3%83%AB%E3%82%B7%E3%83%A5%E3%83%BC%E3%83%86%E3%82%A3%E3%83%B3%E3%82%B0#%E3%82%A4%E3%83%B3%E3%82%B9%E3%83%88%E3%83%BC%E3%83%AB%E3%81%AE%E3%83%88%E3%83%A9%E3%83%96%E3%83%AB%E3%82%B7%E3%83%A5%E3%83%BC%E3%83%86%E3%82%A3%E3%83%B3%E3%82%B0)』へ。**
+
+# Uso
+
+Es un artículo que he comentado.
+
+- [新環境構築にEasyReforge 使ったから自動的に入るやつ全部解説する](https://note.com/kagami_kami/n/n79f46bc6147b)
+
+|![](https://raw.githubusercontent.com/wiki/Zuntan03/EasyReforge/Sample/CheatSheet/Reforge_00_Basic.webp)|![](https://raw.githubusercontent.com/wiki/Zuntan03/EasyReforge/Sample/CheatSheet/Reforge_02_VPred.webp)|
+(Risas)
+|![](https://raw.githubusercontent.com/wiki/Zuntan03/EasyReforge/Sample/CheatSheet/Txt2ImgInpaint.webp)|![](https://raw.githubusercontent.com/wiki/Zuntan03/EasyReforge/Sample/CheatSheet/Reforge_01_Tipo.webp)|
+|![](https://raw.githubusercontent.com/wiki/Zuntan03/EasyReforge/Sample/CheatSheet/TipoWildcard.webp)|![](https://raw.githubusercontent.com/wiki/Zuntan03/EasyReforge/Sample/CheatSheet/TipoWildcardMulti.webp)|
+|![](https://raw.githubusercontent.com/wiki/Zuntan03/EasyReforge/Sample/CheatSheet/FramePlanner.webp)|![](https://raw.githubusercontent.com/wiki/Zuntan03/EasyReforge/Sample/CheatSheet/NoobInpaint.webp)|
+
+# Operaciones básicas
+
+-EasyRefoge.
+- El botón de la derecha produce una imagen.
+- La imagen será guardada en getputReforge\ttt2img-imagesing.
+- Puede ver la imagen generada en getInfiniteImageBrowsing.bats.
+	- プロンプト欄に入力するタグは [Danbooru](https://danbooru.donmai.us/) の左上にある `Search` 欄で、**日本語で検索して調べます** 。
+- En el cuadro de estilo de estilo bajo el botón &quot; General &quot; , seleccione MDM2[4]: LCM, SG Unform para aplicar las preferencias básicas a las configuraciones en la parte inferior y en la parte inferior.
+El uso de fix x 1,5 es un preestablecimiento de la hipótesis.
+- El safe al final de la laptop es una clasificación para TIPO.
+Por favor, elimine si no utiliza TIPO (puede generar una caja de seguridad).
+- Si desea utilizar la configuración normal de alta velocidad sin la Lorra, aplicará el término Eluer a, normal.
+- Si se abre la bobina de la entrada y se activa la entrada de la entrada, se agrega la configuracion asociada a la entrada y se produce.
+Para probar un NSFW de alta reputación, reescribe el chesafe a éxpicity.
+	- 画像生成で問題が発生したら『[画像生成のトラブルシューティング](https://github.com/Zuntan03/EasyReforge/wiki/%E3%83%88%E3%83%A9%E3%83%96%E3%83%AB%E3%82%B7%E3%83%A5%E3%83%BC%E3%83%86%E3%82%A3%E3%83%B3%E3%82%B0#%E7%94%BB%E5%83%8F%E7%94%9F%E6%88%90%E3%81%AE%E3%83%88%E3%83%A9%E3%83%96%E3%83%AB%E3%82%B7%E3%83%A5%E3%83%BC%E3%83%86%E3%82%A3%E3%83%B3%E3%82%B0)』へ。
+- ** El estado del inicio puede cambiarse en la parte inferior izquierda de Settings, en la parte inferior izquierda del programa.
+- Voy a revisar los cambios y los guardaré con un poco de apply.
+- Cuando la configuración se descomprime de la configuración, se vuelve a poner en el estado inicial cuando se deshabilite de getstable-diffiti-refrige/wiborge, hytu-config.jsonig.jsonwords.jsstyles.csvyRefoge. bat.
+- En la parte inferior derecha de la interfaz de VRAM, puede activar la configuración OOM de la pantalla a la izquierda, y el movimiento puede ser cómodo si se especifica, por ejemplo, WhileLow VRAM.
+- Para detener la anotación japonesa de la UI, use el archivo de la legislatura Local Localization de la UI como un steennoon, y la página Apply sessions y la interfaz de Reload.
+- Si desea especificar la opción de la línea de órdenes en el inicio, copia el nombre de la línea de órdenes en el archivo.
+- Reproduce EasyRefoge en ***
+	- 更新で問題が発生したら『[更新のトラブルシューティング](https://github.com/Zuntan03/EasyReforge/wiki/%E3%83%88%E3%83%A9%E3%83%96%E3%83%AB%E3%82%B7%E3%83%A5%E3%83%BC%E3%83%86%E3%82%A3%E3%83%B3%E3%82%B0#%E6%9B%B4%E6%96%B0%E3%81%AE%E3%83%88%E3%83%A9%E3%83%96%E3%83%AB%E3%82%B7%E3%83%A5%E3%83%BC%E3%83%86%E3%82%A3%E3%83%B3%E3%82%B0)』へ。
+
+# Descargar datos adicionales
+
+- En la parte superior izquierda de Search... en la columna superior izquierda de SearchSearch...
+	- [Wiki](https://github.com/zixaphir/Stable-Diffusion-Webui-Civitai-Helper/wiki/Civitai-API-Key) のリンク先をブラウザで翻訳して、内容にそって API Key を取得して、この設定欄にコピペしてから上の `Apply settings` で保存します。
+- Una vez que se haya establecido la tecla Civai, se descargará un modelo, como el modelo, con la tecla " NoooAiEplonPred_StardanderModels.bats."
+- Si no necesita descargar un modelo, ejecute getnoboAiEthlonPred_Stardard.bats.
+- Cuando descargamos datos adicionales, podemos usar comodines de personajes y estilos.
+- ¿Qué es eso?
+- Sólo las mujeres.
+- Comodín de estilo de fusión.
+- Largo: NovoustylesDump: 1 withnobrightlessDump: Estilo Lora y comodines de disparador (V-Pred) NobE se convierte en NobV.
+- Lata: NovoustylesCololection: 1. Software LorarysCololection.
+- Puede descargar datos adicionales directamente en la parte inferior.
+	- `NoobAiEpsilonPred`, `NoobAiVPred`: [NoobAi](https://civitai.com/models/833294) の Epsilon-Prediction 版、V-Prediction 版の関連ファイルをダウンロードします。最初は扱いが簡単な `NoobAiEpsilonPred` がオススメです。
+- Uniminumum: descarga de los archivos mínimos que pueden generar una imagen. Solo se puede descargar sin la configuración de la tecla Civai de la siguiente manera.
+- Constantes: descargan archivos asociados, aparte de los modelos.
+- Selectores: se descargan modelos de osmeme con un total de 100 GB o menos.
+- Voy a descargar todos los archivos relacionados.
+- Puede descargarse por separado con una subcarpeta.
+	- モデルや LoRA は日々新しいモノが公開されますので、[Civitai](https://civitai.com/) で気になったモノを `Civitai Helper` でダウンロードしたり、`Civitai Helper Browser` で直接ダウンロードしてください（Civitai キー設定が必要）。
+
+# Compartir recursos con otros entornos
+
+- Los modelos y Lora se almacenan debajo de la base.
+- Puede compartir modelos y Lora con cada subcarpeta
+-EasyRefoge para ver el modelo de otros entornos o Lora.
+- Ejecutar el modelo de EasyRefoge o Lora desde otro entorno.
+
+# Intentar V-Prediction
+
+* La edición V-Predition de Novya está en desarrollo.
+* ** *En este momento, la calidad se ha deteriorado debido a que no existe ningún LoRA para V-Prediction & ZTSNR.
+
+[追加データのダウンロード](https://github.com/Zuntan03/EasyReforge/#追加データのダウンロード) で Civitai キーを設定してから、`Download/` にある `NoobAiVPred_StandardModels.bat` で V-Pred のモデルや LoRA をダウンロードします。
+
+1. Abajo, a la izquierda, abre Model Smpling for reForge para activar el Model Advanced Model Sumplings.
+- Tenga en cuenta que las funciones de prueba automáticas V-Pred y ZTSNR parecen no funcionar bien en modelos de formación.
+1, DDDM2[4+]: Eureer a CFG+, Beta se aplica con éter y ébano.
+- En algunos modelos, puede generarse incluso con la configuración LMC, SMG Unform.
+Una vez que se produce con un logo, se puede ver la altura de la precisión de aprendizaje en el logo y en el logo.
+
+Lo mismo sucede cuando regresas a E-Pred.
+
+1, DTD2[4]: Seleccione LCM, SGM Unit y aplique el nombre con éi.
+1. Abajo, a la izquierda, abre Model Sumpling for reArchivos para deshabilitar el Model Desvanced Model Sumplings.
+
+# Reproducción reciente
+
+- Si el estilo que ha sido editado por una actualización * se ha vuelto a enrollar, por favor copie y restablezca el archivo de copia de seguridad fechado al lado de la actualización *stable-difficition-webui-reForge\syvers.csvsvy.*
+
+# 2025/05/14
+
+- Añadiendo a la modelo el modelo\Stable-diffion\Noboe\PlamMix_v10.bathis.
+- Si usas HyperDM, parece que la combinación de MDM MDS es buena.
+
+# 2025/05/13
+
+- Añadimos a nuestro modelo el método de búsqueda\Stable-diffon\Novoe_Real\Division_RealAsian_v20.bathis.
+- Cuando se usó HyperDM, parecía que la combinación era buena.
+
+##2025/05/06
+
+- Hemos actualizado las versiones de los siguientes modelos.
+- isoDownload\Stable-diffioon\Noboe\CottonIllius_v20.bathis
+- isoDownload\Stable-diffon\Noboe\songMix_v32.bat2
+- He respondido a las siguientes descargas.
+- /enDownload\Lara\Noob_Bundle\songMixLex.bats
+- /enDownload\VAE\Sdxl\songVae_v10.bats
+- isoDownload\Stable-diffion\Noboe\liyMix_v11.bats
+- isoDownload\Stable-diffion\Noboe\vivivix_v12.bats
+
+##2025/05/04
+
+- Se han añadido A11 y Forge para la revisión sobre la instalación.
+
+##2025/04/25
+
+- 使い方に解説いただいた記事『[新環境構築にEasyReforge 使ったから自動的に入るやつ全部解説する](https://note.com/kagami_kami/n/n79f46bc6147b)』へのリンクを追加しました。
+- Se ha actualizado la versión de los siguientes modelos.
+- isoDownload\Stable-diffon\Noboe\songMix_v30.bats
+- Respondemos a la descarga de la siguiente Lora.
+- /enDownload\Lara\Novoe_Charcia\Gx_GQ_bull_v10.baty
+
+# 2025/04/20
+
+-Heres. fix error del tipo: 'NoneType 'object is not table'
+- La operación de TIPO ha sido corregida por un fallo lento.
+
+# 2025/04/14
+
+- Redimensionamos las versiones de la versión de There Settings-Defaults.
+- En la casilla de verificación de la izquierda, activa o desactiva la casilla de verificación y luego la guarda con el nombre de Settings-Defaultsing.
+![](https://raw.githubusercontent.com/wiki/Zuntan03/EasyReforge/Troubleshoot/NegPipUi.webp)
+
+# 2025/04/13
+
+- [reForge 本家の更新は終了](https://github.com/Panchovix/stable-diffusion-webui-reForge/discussions/354) しました。
+Por favor, use su entorno para Nob o Ilustrio hasta que aparezca un nuevo entorno.
+
+##2025/04/10
+
+- En el proceso de instalación, hemos añadido una instalación de Microsoft Visual C++Redustriable.
+
+##2025/04/09
+
+- en un entorno específico. pydust. bdist_thod not run successfully.
+
+##2025/04/08
+
+- He hecho un sistema de descarga mínima para descargar el modelo de red de control de Ty e Ingert.
+- Hares. El botón " fix " (see Create an upscure version of...) ha corregido un error hasta que se guarde la configuración.
+
+##2025/04/06
+
+![](https://raw.githubusercontent.com/wiki/Zuntan03/EasyReforge/Sample/CheatSheet/NoobInpaint.webp)
+
+- 『[お手軽インペイント書き換え](https://raw.githubusercontent.com/wiki/Zuntan03/EasyReforge/Sample/CheatSheet/NoobInpaint.webp)』のチートシートを追加しました。
+- Una actualización masiva, incluyendo cambios y parches de instalación.
+- Una vez que la primera ejecución de iterate. batsy falla, puede ser posible actualizar correctamente una vez más
+** Si hay algún problema después de la actualización, asegúrese de que no haga clic en "webbui-reFheorge/venv/south" y vuelva a actualizarlo con el nombre "segundate.bat" *
+- El RTTX 50x0 y SageAttention.
+- Podría necesitar una actualización del controlador gráfico.
+- Hiroes. Fix no pudo cambiar el modelo.
+- Se puede usar fuera de línea después de instalarlo.
+- Añadiendo una opción de alta velocidad.
+- コントロールネットの [Noob インペイントモデル](https://huggingface.co/Wenaka/NoobAI_XL_Inpainting_ControlNet_Full)を追加しました。
+- /endDownload\ControlNetContador\NovoE_Innices.bats
+- En el preprocesador de control de Microsoft, se ha añadido un steinchert_only_nooly_lay_language, steinchert_nooware_xlate,
+- Añadido a la predefinición de la red de control.
+- Reaccionamos a la descarga de modelos.
+- Cuando uses un nuevo modelo Ilustraus de Cfg1 a alta velocidad, intentes hacer muchas cosas con tu planificador.
+- isoDownload\Stable-diffion\Noboe\cattower_v12.batsy
+- isoDownload\Stable-diffioon\Noboe\CottonIllius_v10.baty
+- isoDownload\Stable-diffion\Nooome\NovaAnime_v60.bats
+- isoDownload\Stable-diffion\Noboe\SmoothMix.bats
+- isoDownload\Stable-diffon\Nooe_Unicode\NovaFurry_v50.baty
+- Hemos actualizado la versión del modelo.
+- isoDownload\Stable-diffioon\Noboe\LibrasIlliusX_v50.bats
+- isoDownload\Stable-diffon\Noboe\songMix_v22.bats
+- isoDownload\Stable-diffion\Nooe_Real\PanMasterPro_v25.bathis
+- isoDownload\Stable-diffioon\Nooe_Unicode\PVCStyleMoveble_v13a.baty
+- isoDownload\Stable-diffion\NobV\KTtowerV_v17.baty
+- isoDownload\Stable-diffion\NoobV\HikariNoob_v121.bat1
+- isoDownload\Stable-diffon\Nobov\OvidsV_v11.bats
+- isoDownload\Stable-diffon\NoobV_v20.bats
+- He añadido un modelo de detección de ADteiler.
+- isoDownload\adtailer\segm\patters_seg_v3a.baty
+
+##2025/04/05
+
+- Mañana, si no hay nada que pueda hacer, subiré en gran manera la versión de JingreForge, que dejó de actualizar por inconveniencias.
+Por favor, tome una copia de seguridad antes de la actualización y asegúrese de instalar una nueva carpeta.
+- Es el equivalente a Geforce RTX 50x0 en su estado normal.
+
+##2025/03/17
+
+- TheoDownload\Stable-diffioon\Noooe\TanemoMix_v20.bathis.
+- Load\Stable-diffioon\NovoE\CottonNotnob_v20.batsy.
+
+##2025/03/13
+
+- Se ha actualizado la versión de thesesongMax_v15e en / Stable-Diffion/Novore/ ike.
+- Un poco más de lo que he probado con NobV06sHyperDmd: 1.
+
+##2025/03/07
+
+- [TrainTrain](https://github.com/hako-mikan/sd-webui-traintrain) と [SuperMerger](https://github.com/hako-mikan/sd-webui-supermerger) を使えるように `Forge.bat` を追加しました。
+- El ADDFT del tren T-T puede aprender la diferencia de Lora en un minuto.
+		- 『[交替直接差分学習法ADDifT(Alternating Direct Difference Training)の解説](https://note.com/hakomikan/n/n716397e39d56)』
+		- 『[ADDifTの実践1](https://note.com/hakomikan/n/n2a00c2bb39af)』
+- La Lora que aprendió puede combinarse con SuperMerger.
+
+##2025/03/06
+
+- Se ha actualizado la versión de thesesongMax_v14s en / Stable-Diffion/Noboe/ year.
+- Para usarlo en HyperDmd Cfg1, compárelo con los planificadores & hyperDIM.
+- Endrownloader\sgm\asgscHead-seg.batj y steadDownlower\sgmHhair-seg.bat
+
+##2025/03/02
+
+- `Download/Stable-diffusion/NoobE` に [`AniKawa`](https://civitai.com/models/1282887?modelVersionId=1447392) を追加しました。
+
+##2025/02/28
+
+- `Download/Stable-diffusion/NoobE` の [`songMix_v12`](https://civitai.com/models/1286421?modelVersionId=1455149) を [`songMix_v13`](https://civitai.com/models/1286421?modelVersionId=1472562) に更新しました。
+
+##2025/02/25
+
+- Se ha añadido un modelo para the Unicodeny Valley_v10_LcMailexy.
+- En el caso de HyperDmd, la relación entre
+
+##2025/02/24
+
+- スタイルで適用するクォリティタグを [NoobAI-XL User Manual](https://d0xb9r3fg5h.feishu.cn/docx/YpOQdtHTDoetcZxIO9fc33onnee) 準拠にしました。
+- yaa, masterpice, best qualce, best qualce, other 2024, newst, hiedres, absser, geneal, safe # explicity undergeneral es NobI y safe es la reunión de TIPO.
+- Si está editando un estilo, rebote a Copie desde una copia de respaldo fechada al lado de watchtable-difficition-webui-reForge\syverts.csvsvs.
+- `Download/Stable-diffusion/NoobE` に [`songMix_v12`](https://civitai.com/models/1286421?modelVersionId=1455149) モデルを追加しました。
+- 拡張機能に [sd-webui-pnginfo-beautify](https://github.com/bluelovers/sd-webui-pnginfo-beautify) を追加しました。
+
+![](https://raw.githubusercontent.com/wiki/Zuntan03/EasyReforge/log/2502/PngInfo.webp)
+
+##2025/02/23
+
+- Geforce RTX 50x0.
+	- [PyTorch 2.6.0 CUDA 12.8 の torch と torchvision](https://huggingface.co/w-e-w/torch-2.6.0-cu128.nv) をインストールします。
+- La versión del controlador de gráficos N.V.A. debe ser mayor o igual a 0.057.555.
+- No tengo RTX 50x0, por lo que no puedo confirmar el movimiento.
+	![](https://raw.githubusercontent.com/wiki/Zuntan03/EasyReforge/log/2502/Torch260Cuda128.png)
+	- **[PyTorch 2.6.0 では ADetailer が動作しない問題があるそうです（3060 環境でも再現）。](https://note.com/198619891990/n/n609b398d7de2)**
+- Por ahora, la versión volverá a aparecer cuando se ejecute.
+
+##2025/02/22
+
+Es un procedimiento para ajustar la imagen del segundo gato a la primera.
+	- [Twitter](https://x.com/Zuntan03/status/1893213352060416153)、[pixiv](https://www.pixiv.net/artworks/127508681)
+
+|![](https://raw.githubusercontent.com/wiki/Zuntan03/EasyReforge/log/2502/CatDay_0.webp)|![](https://raw.githubusercontent.com/wiki/Zuntan03/EasyReforge/log/2502/CatDay_1.webp)|
+(Risas)
+
+##2025/02/21
+
+- 『無料の [FramePlanner](https://frameplanner-e5569.web.app) で生成画像にセリフ付け』のチートシートを追加しました。
+
+|![](https://raw.githubusercontent.com/wiki/Zuntan03/EasyReforge/log/2502/FramePlanner_0.webp)|![](https://raw.githubusercontent.com/wiki/Zuntan03/EasyReforge/log/2502/FramePlanner_1.webp)|
+(Risas)
+
+![](https://raw.githubusercontent.com/wiki/Zuntan03/EasyReforge/Sample/CheatSheet/FramePlanner.webp)
+
+##2025/02/20
+
+- En respuesta a la descarga de un modelo y de un dominischeBoobay.
+
+とても簡単にセリフを付けられる [FramePlanner](https://frameplanner-e5569.web.app/) を [お試し](https://www.pixiv.net/artworks/127444721)。
+
+[![](https://raw.githubusercontent.com/wiki/Zuntan03/EasyReforge/log/2502/4koma_w.webp)](https://www.pixiv.net/artworks/127444721)
+
+##2025/02/17
+
+- [`DungeonSquadStyle_v30`](https://civitai.com/models/486237?modelVersionId=1399376) の [出力例](https://www.pixiv.net/artworks/127330900) です。
+	- [リンク先](https://www.pixiv.net/artworks/127330900) のオリジナルサイズ画像を `PNG Info` にドラッグ＆ドロップすると、生成設定を確認できます。
+
+|![](https://raw.githubusercontent.com/wiki/Zuntan03/EasyReforge/log/2502/pixelart_0_h.webp)|![](https://raw.githubusercontent.com/wiki/Zuntan03/EasyReforge/log/2502/pixelart_1_h.webp)|![](https://raw.githubusercontent.com/wiki/Zuntan03/EasyReforge/log/2502/pixelart_2_h.webp)|![](https://raw.githubusercontent.com/wiki/Zuntan03/EasyReforge/log/2502/pixelart_3_h.webp)|
+(Risas)
+
+##2025/02/16
+
+- Añadimos a la conversación local LLM que se puede usar para hacer clic en la página de charla de NSFW o para consultar con el amplificador, y a continuación, a JARp_v02.
+Las conversaciones tienden a ser más frecuentes debido al modelo de rol, pero se mantienen lo suficientemente controladas como para ser instrucciones.
+- Me temo que las limitaciones a lo que se refiere a la conversación son más lentas.
+- `Download/Stable-diffusion/NoobE` にアニメモデルの [`AniKawa`](https://huggingface.co/Qnuk/Illustrious_Models_AniKawaXL) を追加しました。
+- `Download/Lora/NoobE_Style` にドット絵スタイルの [`DungeonSquadStyle_v30`](https://civitai.com/models/486237?modelVersionId=1399376) を追加しました。
+- [`MatureRitual_v03e`](https://civitai.com/models/994401?modelVersionId=1345769) を [`MatureRitual_v04`](https://civitai.com/models/994401?modelVersionId=1418875) に更新しました。
+- Corregimos el error de instalar Git en un entorno donde no está instalado.
+
+##2025/02/13
+
+- Añadimos un canal de charla local LLM que se puede usar en la red NSFW o en la consulta de ping-pong.
+- Si quiere hablar con la imagen generada, use el break Llm/7GB_LomimaidMagnum_v4_CP.
+- Si desea charlar sin generar imágenes, use el stake Llm/7GB_LimidaidMagnum_v4_GP.
+Por favor, discúlpense del tema, porque su obsesión ética parece ser diferente de la de LummedMagnum_v4 y la de Verghofnfsword.
+Arrastrar y colocar los archivos **. ggufféilos en un modelo preferido: &quot; Llm/99_ModelDanDarop_Cip. bug &quot; , &quot; , &quot; Llm/99 &quot; ModelDarndDarop_Gp &quot; . bug &quot; . bug &quot; .
+
+##2025/02/12
+
+- reForge の最新版でランタイムエラーが発生するようですので、[昨日のリビジョン](https://github.com/Panchovix/stable-diffusion-webui-reForge/commit/8ac78f65c97908a25c3f47b5311cc7268ff79eea) に固定しました。
+-: config[i] ==_with-name) INTERAL ASSERT FAAD at.\c10cuda\CUDAAA loatherConfig. cpp": 229, please report a bug to PyToolch. control return at runge!=all return returned at lection
+
+##2025/02/09
+
+- Añadiendo la imagen generada automáticamente para mostrarla.
+- Tiene que generarse con épmpn.
+- He añadido un marcador de ubicación para TIPO.
+- Cambié el formato de la imagen generada de chewebppe a éipng.
+
+![](https://raw.githubusercontent.com/wiki/Zuntan03/EasyReforge/log/2502/location.webp)
+
+##2025/02/06
+
+- プロンプトなどのメタ情報を残しながら `*.jpg` や `*.webp` に変換できる、[SdImageDiet](https://github.com/nekotodance/SdImageDiet) に対応しました。
+- Se puede usar si se ejecuta SDImageDiet.bats.
+
+##2025/02/05
+
+- He añadido una hoja de papel de " multiples personajes" para la imagen que me gusta en TIPO.
+
+![](https://raw.githubusercontent.com/wiki/Zuntan03/EasyReforge/Sample/CheatSheet/TipoWildcardMulti.webp)
+
+##2025/02/04
+
+- Instalamos un ipsad-weburi-lora-block-weight, mientras que el souchako-mikanyai fue eliminado.
+- asd-webbui-negpipe, chesd-webui-cd-tuners, para hacer frente a un problema que no se guarda,
+- Debido a que el fallo ha sido corregido, he vuelto a usar la versión más reciente de la versión de "forge-comuple"
+
+##2025/02/03
+
+- Añadimos una hoja de tite de " Generación infinita de imágenes en TIPO."
+- Es más fácil obtener el prefijo de la persona de la imagen nob_1garl que el nombre del archivo, por ejemplo PNG Info.
+- Si el estilo que ha sido editado en la actualización ha vuelto, por favor copie desde un archivo de copia de seguridad fechado junto a stable-diffiti-reForge\sytalles.csv.
+
+El contenido de la columna de texto en la imagen de la hoja de cálculo es:
+
+El modelo es un modelo de tipo NobE que es difícil de deformar en la UTPO, aunque sea contradictoria.
+En el estilo de la derecha, seleccione el estilo " TIPPO 1glil play [Sample] " para pegar una muestra en una viga y " activar ' UTPO para generarla.
+
+prag < lobotV06sHyperDmd:1 Gell, tzio_1rl_, tzio_draw, solo, masterpice, newst, absurd, hippy, explicit, etc.
+Se trata de una muestra de una muestra que se encuentra en la página anterior.
+A partir de la combinación de xilo_1rl. twitl, stello_play_tool, se producen imágenes amplias y amplias a partir de la terminación de la laptop de TIPO.
+
+---
+) < lobv06sHyperDmd: 1-1glil, _BAR, __, solo, masterpice, newst, absurd, highres, explicit, etc.
+○ "fore for play" [inaudible]: wisel/widcards/south.tttll.ttwith.ttt, y así sucesivamente, agregamos los personajes favoritos y los implementos de juego.
+Editar para usted mismo la imagen deseada le permitirá crear una imagen infinitamente mejor.
+
+getgill.ttwith ejecutase ShisSample/nob_1garl.bats para añadir los personajes conocidos a partir del nombre de archivo y la información generada de la imagen DLL.
+Es más difícil copiar la información generada a través de la información generada, por ejemplo, por PNG Info.
+
+Puede añadirle a Lora como lo hizo al principio.
+?Download\NovoE_17Medialist_Hilarukiskini_v10.bat, se puede descargar Lora para probar el personaje de Lora.
+
+La tasa de bateo baja, pero también se puede combinar aleatoriamente con dos personajes.
+
+---
+éso es el tipo de juego que se utiliza en el juego.
+También se pueden añadir clavijas clave a través de las imágenes meta-información de Internet.
+
+Es una suposición para completarla en UTPO, así que no necesitamos un solo clavito.
+Se puede hacer un montón de palillos, pero el ancho de los cambios de la TIPO se reduce.
+
+Se pueden usar y combinar archivos de texto diferentes como getgarl.atl, ftp, ftp, etc.
+
+éanimame, animame coloring, animame screenshot: 1.2)
+La moda puede cambiar por el modelo o por el soporte.
+
+---
+stebbac, greyscale, monocrome, hair, ear, multiple view, center, fell, sticles, policy, eflower
+
+émbolo del fondo: phissimple background o breakite background
+ébanocrome: monocromo
+El color del pelo y de los ojos depende de los personajes.
+Podría ser un poco de soda, un poco de komaa.
+No añadir una corrección, ni un pelo, ni una pelota, ni un lafo.
+
+![](https://raw.githubusercontent.com/wiki/Zuntan03/EasyReforge/Sample/CheatSheet/TipoWildcard.webp)
+
+[過去の更新内容](https://github.com/Zuntan03/EasyReforge/wiki/%E9%81%8E%E5%8E%BB%E3%81%AE%E6%9B%B4%E6%96%B0%E5%86%85%E5%AE%B9)（参考画像もこちらにあります。）
+
+
+# Documentos
+
+- [トラブルシューティング](https://github.com/Zuntan03/EasyReforge/wiki/%E3%83%88%E3%83%A9%E3%83%96%E3%83%AB%E3%82%B7%E3%83%A5%E3%83%BC%E3%83%86%E3%82%A3%E3%83%B3%E3%82%B0)
+- [過去の更新内容](https://github.com/Zuntan03/EasyReforge/wiki/%E9%81%8E%E5%8E%BB%E3%81%AE%E6%9B%B4%E6%96%B0%E5%86%85%E5%AE%B9)
+
+# Licencia
+
+El contenido de este repositorio es [MIT License]te. /CIENSE.txt.]


### PR DESCRIPTION
## Summary
- add Spanish translation README_es.md generated via MarianMT
- link to Spanish translation in original README

## Testing
- `pip install transformers sentencepiece torch --extra-index-url https://download.pytorch.org/whl/cpu --quiet`
- `python translate_readme.py` (then removed script)


------
https://chatgpt.com/codex/tasks/task_e_684106f98aac832ba41074ce64f5636a