### PR TITLE
Add Spanish localization support

### DIFF
--- a/EasyReforge/Forge/ForgeExtension.bat
+++ b/EasyReforge/Forge/ForgeExtension.bat
@@ -92,6 +92,10 @@ if %ERRORLEVEL% neq 0 ( popd & exit /b 1 )
 call %GITHUB_CLONE_OR_PULL% L4Ph stable-diffusion-webui-localization-ja_JP main
 if %ERRORLEVEL% neq 0 ( popd & exit /b 1 )
 
+@REM https://github.com/innovaciones/stable-diffusion-webui-localization-es_ES
+call %GITHUB_CLONE_OR_PULL% innovaciones stable-diffusion-webui-localization-es_ES main
+if %ERRORLEVEL% neq 0 ( popd & exit /b 1 )
+
 popd rem %~dp0..\..\stable-diffusion-webui-forge\extensions
 exit /b 0
 

--- a/EasyReforge/Forge/src/forge_update_config.py
+++ b/EasyReforge/Forge/src/forge_update_config.py
@@ -72,7 +72,7 @@ class ForgeConfig:
         cfg["infotext_skip_pasting"] = ["Emphasis"]
         cfg["interrupt_after_current"] = False
 
-        cfg["bilingual_localization_file"] = "ja_JP"
+        cfg["bilingual_localization_file"] = "es_ES"
         cfg["dp_wildcard_manager_no_sort"] = True
         cfg["tac_showWikiLinks"] = True
         cfg["tipo_no_extra_input"] = True

--- a/EasyReforge/Reforge/ReforgeExtension.bat
+++ b/EasyReforge/Reforge/ReforgeExtension.bat
@@ -102,6 +102,10 @@ if %ERRORLEVEL% neq 0 ( popd & exit /b 1 )
 call %GITHUB_CLONE_OR_PULL% L4Ph stable-diffusion-webui-localization-ja_JP main d639f8ca6d635686806bebfc8fb6efbe9a71e636
 if %ERRORLEVEL% neq 0 ( popd & exit /b 1 )
 
+@REM https://github.com/innovaciones/stable-diffusion-webui-localization-es_ES
+call %GITHUB_CLONE_OR_PULL% innovaciones stable-diffusion-webui-localization-es_ES main
+if %ERRORLEVEL% neq 0 ( popd & exit /b 1 )
+
 popd rem %~dp0..\..\stable-diffusion-webui-reForge\extensions
 exit /b 0
 

--- a/EasyReforge/Reforge/src/reforge_update_config.py
+++ b/EasyReforge/Reforge/src/reforge_update_config.py
@@ -111,7 +111,7 @@ class ReforgeConfig:
     def update_0_1_2(self, cfg):
         cfg["easy_reforge_config_version"] = "0.1.3"
 
-        cfg["bilingual_localization_file"] = "ja_JP"
+        cfg["bilingual_localization_file"] = "es_ES"
 
     def update_0_1_3(self, cfg):
         cfg["easy_reforge_config_version"] = "0.1.4"

--- a/README_es.md
+++ b/README_es.md
@@ -53,7 +53,7 @@ Para probar un NSFW de alta reputación, reescribe el chesafe a éxpicity.
 - Voy a revisar los cambios y los guardaré con un poco de apply.
 - Cuando la configuración se descomprime de la configuración, se vuelve a poner en el estado inicial cuando se deshabilite de getstable-diffiti-refrige/wiborge, hytu-config.jsonig.jsonwords.jsstyles.csvyRefoge. bat.
 - En la parte inferior derecha de la interfaz de VRAM, puede activar la configuración OOM de la pantalla a la izquierda, y el movimiento puede ser cómodo si se especifica, por ejemplo, WhileLow VRAM.
-- Para detener la anotación japonesa de la UI, use el archivo de la legislatura Local Localization de la UI como un steennoon, y la página Apply sessions y la interfaz de Reload.
+- Para cambiar el idioma de la interfaz abre `Settings -> Bilingual Localization` y selecciona `es_ES`.
 - Si desea especificar la opción de la línea de órdenes en el inicio, copia el nombre de la línea de órdenes en el archivo.
 - Reproduce EasyRefoge en ***
 	- 更新で問題が発生したら『[更新のトラブルシューティング](https://github.com/Zuntan03/EasyReforge/wiki/%E3%83%88%E3%83%A9%E3%83%96%E3%83%AB%E3%82%B7%E3%83%A5%E3%83%BC%E3%83%86%E3%82%A3%E3%83%B3%E3%82%B0#%E6%9B%B4%E6%96%B0%E3%81%AE%E3%83%88%E3%83%A9%E3%83%96%E3%83%AB%E3%82%B7%E3%83%A5%E3%83%BC%E3%83%86%E3%82%A3%E3%83%B3%E3%82%B0)』へ。


### PR DESCRIPTION
## Summary
- add Spanish localization to extension setup scripts
- default to `es_ES` in config updaters
- document switching localizations

## Testing
- `python -m py_compile EasyReforge/Forge/src/forge_update_config.py EasyReforge/Reforge/src/reforge_update_config.py`

------
https://chatgpt.com/codex/tasks/task_e_68410ba45cd4832b8f8796bc1160134e